### PR TITLE
New paths for some REW installations on MacOS

### DIFF
--- a/main.js
+++ b/main.js
@@ -1005,10 +1005,14 @@ function findRewPath() {
         commonPaths.push(path.join(progFilesX86, 'REW', 'roomeqwizard.exe'));
     } else if (platform === 'darwin') {
         commonPaths.push('/Applications/REW.app/Contents/MacOS/roomeqwizard'); 
-        commonPaths.push('/Applications/REW.app'); 
+        commonPaths.push('/Applications/REW.app');
+        commonPaths.push('/Applications/REW/REW.app/Contents/MacOS/JavaApplicationStub');
+        commonPaths.push('/Applications/REW/REW.app');
         const home = os.homedir();
         commonPaths.push(path.join(home, 'Applications/REW.app/Contents/MacOS/roomeqwizard'));
         commonPaths.push(path.join(home, 'Applications/REW.app'));
+        commonPaths.push(path.join('Applications/REW/REW.app/Contents/MacOS/JavaApplicationStub'));
+        commonPaths.push(path.join(home, 'Applications/REW/REW.app'));
     } else { 
         console.warn("Automatic REW path detection on Linux is limited. Checking common PATH locations.");
         return 'roomeqwizard';


### PR DESCRIPTION
For some reason on some Macs REW is on /Applications/REW/REW.app I think this was an older path used on REW and users that update their installation instead of a clean one end up with this path also.

Added to the common search list.
