### PR TITLE
On MacOS Sequoia Acoustica thinks REW is always running

### DIFF
--- a/main.js
+++ b/main.js
@@ -957,7 +957,7 @@ function isProcessRunning(processName) {
             cmd = `tasklist /FI "IMAGENAME eq ${processName}" /NH`;
         } else if (platform === 'darwin') {
             const escapedName = processName.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\__STRING_304__');
-            cmd = `pgrep -fli "${escapedName}"`; 
+            cmd = `pgrep -fl "${escapedName}"`; 
         } else { 
             const escapedName = processName.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\__STRING_306__');
             cmd = `pgrep -fli "${escapedName}"`;

--- a/main.js
+++ b/main.js
@@ -985,7 +985,6 @@ function findRewPath() {
         commonPaths.push(path.join(progFilesX86, 'REW', 'roomeqwizard.exe'));
     } else if (platform === 'darwin') {
         commonPaths.push('/Applications/REW.app/Contents/MacOS/roomeqwizard'); 
-        commonPaths.push('/Applications/REW.app'); 
         commonPaths.push('/Applications/REW.app');
         commonPaths.push('/Applications/REW/REW.app/Contents/MacOS/JavaApplicationStub');
         commonPaths.push('/Applications/REW/REW.app');


### PR DESCRIPTION
On MacOS Sequoia there is always a running process (ApplicationFirewall) that match the pgrep, the solution is to remove the case insensitive search.

Also there was a duplicated line on REW search for MacOS