### PR TITLE
Use run-script-os to detect and build on each supported plataform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "a1-evo-acoustica",
-  "version": "4.0",
+  "version": "4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "a1-evo-acoustica",
-      "version": "4.0",
+      "version": "4.5",
       "dependencies": {
         "inquirer": "^8.2.4",
         "open": "^8.4.0",
@@ -16,7 +16,8 @@
         "a1-evo-acoustica": "main.js"
       },
       "devDependencies": {
-        "pkg": "^5.8.1"
+        "pkg": "^5.8.1",
+        "run-script-os": "^1.1.6"
       }
     },
     "node_modules/@babel/generator": {
@@ -1596,6 +1597,17 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "run-os": "index.js",
+        "run-script-os": "index.js"
       }
     },
     "node_modules/rxjs": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
     "build-linux": "pkg . --targets node18-linux-x64 --output a1-evo-acoustica-linux",
     "build-macos-x64": "pkg . --targets node18-macos-x64 --output a1-evo-acoustica-macos-x64",
     "build-macos-arm64": "pkg . --targets node18-macos-arm64 --output a1-evo-acoustica-macos-arm64",
-    "set-policy": "Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope CurrentUser -Force",
+    "build-macos": "npm run build-macos-arm64 && npm run build-macos-x64",
+    "build-windows-on-unix": "pkg . --targets node18-win-x64 --output a1-evo-acoustica-win-x64",
     "build-windows": "pwsh -NoProfile -ExecutionPolicy Unrestricted -Command pkg . --targets node18-win-x64 --output a1-evo-acoustica-win-x64",
-    "build": "npm run build-windows && npm run build-linux && npm run build-macos-x64 && npm run build-macos-arm64"
+    "build:nix": "echo Building on Linux/MacOS && npm run build-linux && npm run build-macos && npm run build-windows-on-unix",
+    "build:windows": "echo Building on Windows && npm run build-windows && npm run build-linux && npm run build-macos-x64",
+    "build": "run-script-os"
   },
   "author": "OCA",
   "dependencies": {
@@ -21,7 +24,8 @@
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
-    "pkg": "^5.8.1"
+    "pkg": "^5.8.1",
+    "run-script-os": "^1.1.6"
   },
   "pkg": {
     "scripts": [


### PR DESCRIPTION
Same as PR #22 but for new build.

Please note that package-json.lock change seems huge due to you uploading files instead of pushing to the Github repo. This leads to CRLF vs LF conflicts so each line is different (main.js is a different history).

The only real change on the package-lock.json is the addition of run-script-os as development dependency. You can try cloning my repo on a different folder. Just open pwsh and run:

```
git clone https://github.com/pulento/A1EvoAcoustica.git
cd A1EvoAcoustica
npm install
npm run build
```

