### PR TITLE
Automatic releases on version change in package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,58 +1,123 @@
-name: Create Release
+name: Create Release on Version Bump
 
 on:
   workflow_dispatch:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+    paths:
+      - "package.json"
 
 jobs:
-  build-and-release:
-    name: Build and Release
+  check-version-and-release:
+    name: Check Version and Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
+    outputs:
+      new_version: ${{ steps.check_version.outputs.new_version }}
+      should_release: ${{ steps.check_version.outputs.should_release }}
+      tag_name: ${{ steps.check_version.outputs.tag_name }}
+
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Check for version change in package.json
+        id: check_version
+        run: |
+          echo "Checking for version change in package.json..."
+          # Get current version
+          # Use `|| echo ""` in case package.json is malformed or version field is missing,
+          # though a build would likely fail later anyway.
+          current_version=$(jq -r .version package.json || echo "")
+          echo "Current version: $current_version"
+
+          # Get previous version
+          # Use `git show HEAD~1:package.json` to get the content of package.json from the previous commit
+          # Handle error if HEAD~1:package.json doesn't exist (e.g., first commit in repo with package.json)
+          previous_version=$(git show HEAD~1:package.json 2>/dev/null | jq -r .version || echo "")
+          echo "Previous version: $previous_version"
+
+          if [ -z "$current_version" ]; then
+            echo "Could not extract current version from package.json. Exiting."
+            echo "should_release=false" >> $GITHUB_OUTPUT
+            exit 0 # Or exit 1 to fail the workflow
+          fi
+
+          if [ "$current_version" != "$previous_version" ]; then
+            echo "Version changed from $previous_version to $current_version. Proceeding with release."
+            echo "new_version=$current_version" >> $GITHUB_OUTPUT
+            echo "tag_name=v$current_version" >> $GITHUB_OUTPUT
+            echo "should_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version $current_version has not changed. No release will be created."
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Git Tag
+        if: steps.check_version.outputs.should_release == 'true'
+        run: |
+          TAG_NAME="v${{ steps.check_version.outputs.new_version }}"
+          echo "Creating and pushing tag: $TAG_NAME"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # --- Build and Release Steps (conditional on version change) ---
 
       - name: Set up Node.js
+        if: steps.check_version.outputs.should_release == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: "npm"
 
       - name: Install dependencies
+        if: steps.check_version.outputs.should_release == 'true'
         run: npm ci
 
       - name: Build Linux executable
+        if: steps.check_version.outputs.should_release == 'true'
         run: npm run build-linux
 
       - name: Build MacOS x64 executable
+        if: steps.check_version.outputs.should_release == 'true'
         run: npm run build-macos-x64
 
       - name: Build MacOS arm64 executable
+        if: steps.check_version.outputs.should_release == 'true'
         run: npm run build-macos-arm64
 
       - name: Build Windows executable
+        if: steps.check_version.outputs.should_release == 'true'
         run: npm run build-windows
 
       - name: Create Release Entry
+        if: steps.check_version.outputs.should_release == 'true'
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref_name }}
+          tag_name: ${{ steps.check_version.outputs.tag_name }}
+          release_name: Release ${{ steps.check_version.outputs.tag_name }}
           body: |
-            Automated release for ${{ github.ref_name }}
-            Contains Linux, MacOS x64 and Windows executables.
+            Automated release for version ${{ steps.check_version.outputs.new_version }}
+            Contains Linux, MacOS (x64, arm64), and Windows (x64) executables.
           draft: false
           prerelease: false
 
       - name: Upload Linux Asset to Release
+        if: steps.check_version.outputs.should_release == 'true'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,6 +128,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload MacOS x64 Asset to Release
+        if: steps.check_version.outputs.should_release == 'true'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -73,6 +139,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload MacOS arm64 Asset to Release
+        if: steps.check_version.outputs.should_release == 'true'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -83,6 +150,7 @@ jobs:
           asset_content_type: application/octet-stream
 
       - name: Upload Windows Asset to Release
+        if: steps.check_version.outputs.should_release == 'true'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Refactor release workflow to trigger on version bump in package.json and enhance version checking logic.

This will allow Serko to ignore Github apart from maybe adding the changelog to the new release :P 

Which you can do here: 

![image](https://github.com/user-attachments/assets/676c7f5d-cd08-4211-962e-91d5b5a22292)

![image](https://github.com/user-attachments/assets/03b98104-0fbe-42fb-8b6a-e1116069b656)
