### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a1-evo-acoustica",
-  "version": "6.1",
+  "version": "6.2",
   "description": "Sound optimizer tool for Denon & Marantz AVRs",
   "main": "main.js",
   "bin": "main.js",


### PR DESCRIPTION
• Removed minimum crossover restriction from basic MultEQ models and added all-pass filter checks to fronts + sub (only if option is enabled and still will not be possible for speakers). They might get lucky in a lower crossover frequency. Chances are still highest with Xovers at 250Hz if you can manage bass localization with more central subwoofer placement. • Minor speed gains for general algos (about 5%)
• Minor UI tweaks (thanks to cantrellpc)
• No other change